### PR TITLE
Rotate access keys using MFA session after assumeRole has been succesfully completed

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,28 @@ Now in order to assume a role on a subaccount, you can run something like this
 aws_assume AccountName MyRoleOnSubAccount
 ```
 
+### Required IAM permissions
+
+#### AssumeRole
+
+For assuming a role in another account `awstools` needs the following permissions:
+
+- `iam:GetUser`
+- `iam:ListAccessKeys`
+
+*Note: `awstools` is using the MFA authenticated sessions for operations on your AWS access key.*
+
+#### Access Key Rotation
+
+For rotating access keys on the relevant account `awstools` needs the following permissions:
+
+- `iam:GetUser`
+- `iam:CreateAccessKey`
+- `iam:DeleteAccessKey`
+- `iam:ListAccessKeys`
+- `iam:UpdateAccessKey`
+
+*Note: `awstools` is using the MFA authenticated sessions for operations on your AWS access key.*
 
 # License
 

--- a/assume.go
+++ b/assume.go
@@ -48,16 +48,16 @@ func assumeRole(account, role string) {
 	role = adjustRoleName(role)
 
 	err := tryToAssumeRole(account, role)
-	if err != nil {
-		needToBeRotatedChan := make(chan bool)
-		go isNeedRotateKey(needToBeRotatedChan)
 
+	if err != nil {
 		getMainAccountMfaSessionToken()
 		err = tryToAssumeRole(account, role)
 		if err != nil {
 			log.Fatalln(err)
 		}
 
+		needToBeRotatedChan := make(chan bool)
+		go isNeedRotateKey(needToBeRotatedChan)
 		if <-needToBeRotatedChan {
 			rotateMainAccountKey()
 		}
@@ -65,7 +65,7 @@ func assumeRole(account, role string) {
 }
 
 func isNeedRotateKey(needToBeRotated chan<- bool) {
-	session := sess.New(config.Current.Profiles.MainAccount)
+	session := sess.New(config.Current.Profiles.MainAccountMfaSession)
 	cl := iam.New(session)
 
 	keyId := cred.GetMainAccountKeyId(config.Current.Profiles.MainAccount)


### PR DESCRIPTION
I'm trying to resolve what seems to me is a tiny logic bug introduced with the key rotation feature. `ListAccessKeys`, as pretty much of the `*AccessKeys`, is, in my opinion, highly privileged and a user should not be capable of accessing them without having authenticated through a second factor beforehand.

Hence the reordering of the function calls, although I admit it sort of defeats the purpose of using the goroutine to determine the key lifetime value :wink: 

With this change I can safely have

```
"iam:CreateAccessKey"
"iam:DeleteAccessKey"
"iam:ListAccessKeys"
"iam:UpdateAccessKey"
```

behind a

```
"aws:MultiFactorAuthPresent": "true"
```

directive without having to worry about the missing second factor.