### PR TITLE
Use MFA session for key rotation

### DIFF
--- a/assume.go
+++ b/assume.go
@@ -49,8 +49,6 @@ func assumeRole(account, role string) {
 
 	err := tryToAssumeRole(account, role)
 	if err != nil {
-		needToBeRotatedChan := make(chan bool)
-		go isNeedRotateKey(needToBeRotatedChan)
 
 		getMainAccountMfaSessionToken()
 		err = tryToAssumeRole(account, role)
@@ -58,14 +56,14 @@ func assumeRole(account, role string) {
 			log.Fatalln(err)
 		}
 
-		if <-needToBeRotatedChan {
-			rotateMainAccountKey()
+		if needRotateKey() {
+			rotateMainAccountKey(iam.New(sess.New(config.Current.Profiles.MainAccountMfaSession)))
 		}
 	}
 }
 
-func isNeedRotateKey(needToBeRotated chan<- bool) {
-	session := sess.New(config.Current.Profiles.MainAccount)
+func needRotateKey() bool {
+	session := sess.New(config.Current.Profiles.MainAccountMfaSession)
 	cl := iam.New(session)
 
 	keyId := cred.GetMainAccountKeyId(config.Current.Profiles.MainAccount)
@@ -85,7 +83,10 @@ func isNeedRotateKey(needToBeRotated chan<- bool) {
 		log.Fatalln("Cannot get creation time for key", keyId)
 	}
 
-	needToBeRotated <- int(time.Now().Sub(creationTime).Minutes()) >= config.Current.KeyRotationIntervalMinutes
+	log.Println("Interval:", config.Current.KeyRotationIntervalMinutes)
+	log.Println("Lifetime:", int(time.Now().Sub(creationTime).Minutes()))
+
+	return int(time.Now().Sub(creationTime).Minutes()) >= config.Current.KeyRotationIntervalMinutes
 }
 
 func adjustAccountName(account string) string {

--- a/assume.go
+++ b/assume.go
@@ -83,9 +83,6 @@ func needRotateKey() bool {
 		log.Fatalln("Cannot get creation time for key", keyId)
 	}
 
-	log.Println("Interval:", config.Current.KeyRotationIntervalMinutes)
-	log.Println("Lifetime:", int(time.Now().Sub(creationTime).Minutes()))
-
 	return int(time.Now().Sub(creationTime).Minutes()) >= config.Current.KeyRotationIntervalMinutes
 }
 

--- a/rotate_key.go
+++ b/rotate_key.go
@@ -14,12 +14,12 @@ import (
 )
 
 func rotateMainAccountKeyAction(*cli.Context) error {
-	rotateMainAccountKey()
+	client := iam.New(sess.New(config.Current.Profiles.MainAccount))
+	rotateMainAccountKey(client)
 	return nil
 }
 
-func rotateMainAccountKey() {
-	client := iam.New(sess.New(config.Current.Profiles.MainAccount))
+func rotateMainAccountKey(client *iam.IAM) {
 	key, err := client.CreateAccessKey(&iam.CreateAccessKeyInput{
 		UserName: aws.String(getUserName()),
 	})


### PR DESCRIPTION
Second try :smile: 

I made sure to not have an impact on the separate, "regular" rotation routine, although it will fail for people which require MFA authentication for key rotation (we might want to refactor this later).

I'm now passing a IAM client to the key rotation, which makes it easier to utilize the function across boundaries.

In general, the session handling isn't very robust and is probably using 100 different sessions throughout, but one step at a time :wink: 
